### PR TITLE
Allow uloz.to domain, remove useless package and fix bug

### DIFF
--- a/host/INFO
+++ b/host/INFO
@@ -1,6 +1,6 @@
 {
 "name": "ulozto",
-"hostprefix": "ulozto.cz",
+"hostprefix": "ulozto.cz,ulozto.sk,uloz.to",
 "displayname": "ulozto.cz",
 "version": "8.2",
 "authentication": "no",

--- a/package/scripts/postinst
+++ b/package/scripts/postinst
@@ -1,3 +1,2 @@
 #!/bin/sh
-
-cd /var/packages/Ulozto/target && npm install request
+exit 0

--- a/service/api.js
+++ b/service/api.js
@@ -132,7 +132,7 @@ UloztoDownloadApi.prototype.processDownloadLink = function(err, res, body)
 
     if (body.indexOf(this._formId) != -1)
     {
-        this.processRequest(body);
+        this.processRequest(err, res, body);
         return;
     }
 

--- a/service/server.js
+++ b/service/server.js
@@ -120,8 +120,10 @@ Session.prototype.doSearch = function(term)
 
 Session.prototype.getDownload = function(lnk)
 {
+  lnk = lnk.replace("http://uloz.to", "");
   lnk = lnk.replace("http://ulozto.cz", "");
   lnk = lnk.replace("http://ulozto.sk", "");
+  lnk = lnk.replace("https://uloz.to", "");
   lnk = lnk.replace("https://ulozto.cz", "");
   lnk = lnk.replace("https://ulozto.sk", "");
 


### PR DESCRIPTION
* I have added uloz.to to the project, because it is as of this moment the main domain and it didn't work (likely culprit of  #19, i got a similar message).
* I have also modified the host file to use all three domains. Thanks to that download station will recognize links and the downloaded file is a desired file instead of a download page.
* There was a bug with passing wrong parameters to a function (free download only)
* I have removed request library from package postinstallation script, because the node service no longer depends on it.